### PR TITLE
Add backwards compatibility for Ansible 2.9

### DIFF
--- a/roles/auto_registration_verification/tasks/detect_provider.yml
+++ b/roles/auto_registration_verification/tasks/detect_provider.yml
@@ -5,10 +5,24 @@
   when: auto_registration_provider is not defined and ansible_bios_version is search('(?i)amazon')
 
 - name: check for Azure asset tag
-  ansible.builtin.set_fact:
-    auto_registration_provider: MSAZ
-  when: auto_registration_provider is not defined and ansible_chassis_asset_tag == '7783-7084-3265-9085-8269-3286-77'
-  
+  block:
+    - name: find asset tag via dmi (Ansible <2.10)
+      ansible.builtin.slurp:
+        src: /sys/devices/virtual/dmi/id/chassis_asset_tag
+      register: chassis_asset_tag_file
+      when: ansible_chassis_asset_tag is not defined
+
+    - name: set ansible_chassis_asset_tag fact for future compatibility
+      ansible.builtin.set_fact:
+        ansible_chassis_asset_tag: "{{ chassis_asset_tag_file['content'] | b64decode | trim }}"
+      when: chassis_asset_tag_file is not skipped
+
+    - name: check for Azure asset tag
+      ansible.builtin.set_fact:
+        auto_registration_provider: MSAZ
+      when: ansible_chassis_asset_tag is defined and ansible_chassis_asset_tag == '7783-7084-3265-9085-8269-3286-77'
+  when: auto_registration_provider is not defined
+
 - name: ensure cloud provider was detected or already provided
   fail:
     msg: Unable to detect cloud provider for host


### PR DESCRIPTION
The `ansible_chassis_asset_tag` fact we use to detect Azure VMs was only added in Ansible 2.10. For versions of Ansible where this fact is not defined, the `auto_registration_verification` role now reads it from sysfs.