### PR TITLE
Check the cloud sources nickname before change

### DIFF
--- a/plugins/modules/cloud_provider_account.py
+++ b/plugins/modules/cloud_provider_account.py
@@ -171,8 +171,8 @@ def run_module():
         result['changed'] = True
         account = new_account
     else:
-        # Update existing account if nickname is different
-        if module.params['nickname'] and module.params['nickname'] != account['nickname']:
+        # Update existing account if nickname is different and was not autocreated by Cloud Sources
+        if module.params['nickname'] and account['nickname'] != 'Created by Sources' and module.params['nickname'] != account['nickname']:
             if module.check_mode:
                 return_changed(module)
             updated_account = {'nickname': module.params['nickname']}


### PR DESCRIPTION
resolves #10

This checks for `Created by Sources` nickname before altering the nickname for the cloud access record.

Cloud Sources[1] has an automated process that updates a record in Cloud Access[2]. When this nickname is changed, Cloud Sources will periodically update the Cloud Access record and overwrite and nickname that was altered.

This results in this role / module and Cloud Sources overwriting each other's changes everytime this role / module is ran.

1: https://console.redhat.com/settings/sources
2: https://access.redhat.com/management/cloud